### PR TITLE
Add iehlist.sh to samples

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -10,7 +10,7 @@ There are also longer scripts that can be useful:
 |[chkptf.sh](chkptf.sh) | Print out what PTFs have been applied to a particular CSI/Target Zone.
 |[dcat.sh](dcat.sh) | Cat sequential datasets or PDS members (supports wildcards in dataset and member).
 |[dump_and_filter_racf.sh](dump_and_filter_racf.sh) | Dump and Filter RACF database for two record types.
-|[iehlist](iehlist.sh) | Run IEHLIST to get the directory information for a data set.
+|[listdirinfo](listdirinfo.sh) | Use IEHLIST to get the directory information for a data set.
 |[rcvptf.sh](rcvptf.sh) | Receive a PTF that you have uploaded to the Unix System Services zFS file system from ShopZ.
 |[ispfcmd.sh](ispfcmd.sh) | Run an ISPF command from Unix System Services.
 |[mps.sh](mps.sh) | Display active MVS processes.

--- a/samples/README.md
+++ b/samples/README.md
@@ -10,6 +10,7 @@ There are also longer scripts that can be useful:
 |[chkptf.sh](chkptf.sh) | Print out what PTFs have been applied to a particular CSI/Target Zone.
 |[dcat.sh](dcat.sh) | Cat sequential datasets or PDS members (supports wildcards in dataset and member).
 |[dump_and_filter_racf.sh](dump_and_filter_racf.sh) | Dump and Filter RACF database for two record types.
+|[iehlist](iehlist.sh) | Run IEHLIST to get the directory information for a data set.
 |[rcvptf.sh](rcvptf.sh) | Receive a PTF that you have uploaded to the Unix System Services zFS file system from ShopZ.
 |[ispfcmd.sh](ispfcmd.sh) | Run an ISPF command from Unix System Services.
 |[mps.sh](mps.sh) | Display active MVS processes.

--- a/samples/iehlist.sh
+++ b/samples/iehlist.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+        cat << EOF
+usage:
+$0 <data set name>
+EOF
+        exit 1
+fi
+
+data_set=$1
+
+volume=$(dls -s ${data_set} | awk -F ' ' '{print $5}')
+
+mvscmd --pgm=IEHLIST \
+       --sysprint=stdout \
+       --dd1=${data_set},shr,volumes=${volume} \
+    --sysin=stdin <<zz
+ LISTPDS VOL=3390=${volume},FORMAT,                                       X
+               DSNAME=${data_set}
+zz

--- a/samples/iehlist.sh
+++ b/samples/iehlist.sh
@@ -17,7 +17,7 @@ volume=$(dls -s ${data_set} | awk -F ' ' '{print $5}')
 mvscmd --pgm=IEHLIST \
        --sysprint=stdout \
        --dd1=${data_set},shr,volumes=${volume} \
-    --sysin=stdin <<zz
+       --sysin=stdin <<zz
  LISTPDS VOL=3390=${volume},FORMAT,                                       X
                DSNAME=${data_set}
 zz

--- a/samples/listdirinfo.sh
+++ b/samples/listdirinfo.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #!/bin/sh
 #
 # Use IEHLIST to get the directory information for a data set.

--- a/samples/listdirinfo.sh
+++ b/samples/listdirinfo.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#!/bin/sh
+#
+# Use IEHLIST to get the directory information for a data set.
+#
+# Copyright IBM Corp. 2022
+#
 
 set -e
 


### PR DESCRIPTION
This is a wrapper for the JCL and volume extraction logic used to run IEHLIST against a data set to get it's directory information.

Usage:
```shell
./iehlist MY.PDS.DATASET
```