### PR TITLE
Allow for second column to be non blank

### DIFF
--- a/samples/one-liners.md
+++ b/samples/one-liners.md
@@ -225,8 +225,8 @@ job="STC01455"
 opts='-d'
 pcon ${opts} | awk -vjob="${job}" '
  BEGIN { trace=0 }
- /^O|^M|^N|^W|^X/ { if ($6 == job) { trace=1; print; } else { trace=0; }  }
- /^S|^L|^E|^D/  { if (trace) { print; } }
+ /^O|^M|^N|^W|^X/ { if ( substr($0 ,38 ,8) == job ) { trace=1; print; } else { trace=0; }  }
+ /^S|^L|^E|^D/  { if (trace) { print; } }'
 ```
 
 ### Refresh the LLA


### PR DESCRIPTION
Updated **Print a job's console log**
When the syslog has a second character that is not a space the this message is not extracted. [Valid second characters](https://www.ibm.com/docs/en/zos/3.1.0?topic=automation-syslog-records).
The missing end quote was also added
